### PR TITLE
Jump to module definition on windows.

### DIFF
--- a/lib/elixir-goto-definition-provider.coffee
+++ b/lib/elixir-goto-definition-provider.coffee
@@ -71,7 +71,8 @@ class ElixirGotoDefinitionProvider
           return
 
       pane = atom.workspace.getActivePane()
-      [file_path, line] = file.split(':')
+      # "_" is match group 0, which is the original file name;
+      [_, file_path, line] = file.match /(.*):(\d+)/
       atom.workspace.open(file_path, {initialLine: parseInt(line-1 || 0), searchAllPanes: true}).then (editor) ->
         pane.activateItem(editor)
         gotoFirstNonCommentPosition(editor)


### PR DESCRIPTION
Given a module Foo, the windows file is  C:\....\....\foo.exs:1. Because
of the "C:" part, the split by ':' doesn't really work. The fix is to
use regular expression to capture the pattern "(any text):(any number)" and treat (any text) as a file name and (any number) as the line number. 