### PR TITLE
#49 Stop using ::shadow pseudo-selectors for atom-text-editor

### DIFF
--- a/styles/atom-elixir.less
+++ b/styles/atom-elixir.less
@@ -145,10 +145,10 @@
   overflow: scroll;
   background-color: @panel-heading-background-color;
 
-  .editor .gutter, atom-text-editor::shadow .gutter {
-  	.line-numbers {
-  		width: 42px;
-  	}
+  .editor .gutter, atom-text-editor.editor .gutter {
+    .line-numbers {
+      width: 42px;
+    }
   }
 
   .input-block {
@@ -173,11 +173,11 @@
   }
 }
 
-atom-text-editor::shadow .editor-contents--private .highlight.keyclick > .region {
+atom-text-editor.editor .editor-contents--private .highlight.keyclick > .region {
   border-bottom: 1px solid @syntax-text-color;
 }
 
-atom-text-editor:not([mini]).keyclick::shadow .editor-contents--private {
+atom-text-editor:not([mini]).keyclick.editor .editor-contents--private {
   /**
    * Unfortunately, this cannot be a property of `.keyclick .region`:
    * https://discuss.atom.io/t/some-css-styles-not-honored-by-decorations/11662


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.