### PR TITLE
Require Atom 1.13.0 and above after fixing deprecated styles

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -44,7 +44,7 @@ getDocURL = (mod, func, arity) ->
     "http://www.erlang.org/doc/man/#{mod.replace(/^:/, '')}.html#{erl_func_arity}"
   else
     module = mod || 'Kernel'
-    "http://elixir-lang.org/docs/v#{elixir_version}/elixir/#{module}.html#{elixir_func_arity}"
+    "https://hexdocs.pm/elixir/#{elixir_version}/#{module}.html#{elixir_func_arity}"
 
 convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
   if fontFamily = atom.config.get('editor.fontFamily')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/msaraiva/atom-elixir",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.13.0"
   },
   "dependencies": {
     "marked": "^0.3.5",


### PR DESCRIPTION
See #53.